### PR TITLE
Implement baseline Kaggle training script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 numpy
 pandas
-requests
-flask
+scikit-learn
+torch
+transformers
+datasets

--- a/src/main.py
+++ b/src/main.py
@@ -1,1 +1,7 @@
-print("Template Python app is running in Docker.")
+# %%
+print("Jigsaw Agile modeling utilities.")
+
+# %%
+if __name__ == "__main__":
+    print("Use train.py to run model training.")
+

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,66 @@
+# %%
+import pandas as pd
+from datasets import load_dataset
+from transformers import AutoTokenizer, AutoModelForSequenceClassification, TrainingArguments, Trainer
+from sklearn.metrics import accuracy_score, f1_score
+import torch
+
+# %%
+# Load data from CSV files placed in the working directory
+# Expected files: train.csv with columns ['text', 'label']
+dataset = load_dataset("csv", data_files={"train": "train.csv", "validation": "validation.csv"})
+
+# %%
+# Initialize tokenizer and model
+model_name = "distilbert-base-uncased"
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+model = AutoModelForSequenceClassification.from_pretrained(model_name, num_labels=dataset['train'].features['label'].num_classes)
+
+# %%
+# Tokenization function
+def tokenize(batch):
+    return tokenizer(batch["text"], padding=True, truncation=True)
+
+# %%
+# Tokenize datasets
+tokenized = dataset.map(tokenize, batched=True)
+
+# %%
+# Compute metrics
+def compute_metrics(pred):
+    labels = pred.label_ids
+    preds = pred.predictions.argmax(-1)
+    return {
+        "accuracy": accuracy_score(labels, preds),
+        "f1": f1_score(labels, preds, average="macro"),
+    }
+
+# %%
+# Training arguments
+training_args = TrainingArguments(
+    output_dir="./results",
+    evaluation_strategy="epoch",
+    num_train_epochs=1,
+    per_device_train_batch_size=8,
+    per_device_eval_batch_size=8,
+    save_total_limit=1,
+)
+
+# %%
+# Trainer setup
+trainer = Trainer(
+    model=model,
+    args=training_args,
+    train_dataset=tokenized["train"],
+    eval_dataset=tokenized["validation"],
+    compute_metrics=compute_metrics,
+)
+
+# %%
+# Train the model
+trainer.train()
+
+# %%
+# Save the model
+trainer.save_model("./model")
+


### PR DESCRIPTION
## Summary
- add Kaggle libraries to requirements
- add training pipeline using transformers & datasets
- update main entrypoint message

## Testing
- `python -m py_compile src/main.py src/train.py`


------
https://chatgpt.com/codex/tasks/task_e_6883c42bfdd8832cad0329cfee5f3a37